### PR TITLE
add double colon to pseudo elements

### DIFF
--- a/tinyreset.scss
+++ b/tinyreset.scss
@@ -112,8 +112,8 @@ blockquote,
 q {
     quotes: none;
 
-    &:before,
-    &:after {
+    &::before,
+    &::after {
         content: '';
         content: none;
     }


### PR DESCRIPTION
> Sometimes you will see double colons (::) instead of just one (:). This is part of CSS3 and an attempt to distinguish between pseudo-classes and pseudo-elements. Most browsers support both values.

https://developer.mozilla.org/en/docs/Web/CSS/Pseudo-elements